### PR TITLE
Strip converted numbers

### DIFF
--- a/numbertoletters/__init__.py
+++ b/numbertoletters/__init__.py
@@ -57,7 +57,7 @@ def number_to_letters(number):
         number, decimals = ('%.2f' % number).split('.')
     number = int(number)
     decimals = int(decimals)
-    negative =  number < 0
+    negative = number < 0
     if negative:
         number = abs(number)
     if not (0 <= number < 999999999):
@@ -94,7 +94,7 @@ def number_to_letters(number):
         converted += 'con %s' % decimals
     if negative:
         converted = 'menos %s' % converted
-    return converted
+    return converted.strip()
 
 
 def __convertNumber(n):
@@ -105,15 +105,15 @@ def __convertNumber(n):
     if(n == '100'):
         output = 'cien '
     elif(n[0] != '0'):
-        output = CENTENAS[int(n[0])-1]
+        output = CENTENAS[int(n[0]) - 1]
 
     k = int(n[1:])
     if(k <= 20):
         output += UNIDADES[k]
     else:
         if((k > 30) & (n[2] != '0')):
-            output += '%sy %s' % (DECENAS[int(n[1])-2], UNIDADES[int(n[2])])
+            output += '%sy %s' % (DECENAS[int(n[1]) - 2], UNIDADES[int(n[2])])
         else:
-            output += '%s%s' % (DECENAS[int(n[1])-2], UNIDADES[int(n[2])])
+            output += '%s%s' % (DECENAS[int(n[1]) - 2], UNIDADES[int(n[2])])
 
     return output

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,22 +28,22 @@ class TestToWord(unittest.TestCase):
         ]
 
         results = [
-            'un ',
-            'cien ',
-            'ciento diez ',
-            'ciento un ',
-            'dos mil ',
-            'ciento dos mil ',
-            'trescientos mil ',
-            'cuatro millones ',
-            'quinientos millones ',
-            'novecientos noventa y nueve millones novecientos noventa y nueve mil novecientos noventa y ocho ',
-            'ochocientos veintiseis con dos ',
-            'doscientos tres con un ',
-            'veinti uno con diez ',
-            'cero con veinticuatro ',
-            'cero ',
-            'menos doscientos treinta con cincuenta '
+            'un',
+            'cien',
+            'ciento diez',
+            'ciento un',
+            'dos mil',
+            'ciento dos mil',
+            'trescientos mil',
+            'cuatro millones',
+            'quinientos millones',
+            'novecientos noventa y nueve millones novecientos noventa y nueve mil novecientos noventa y ocho',
+            'ochocientos veintiseis con dos',
+            'doscientos tres con un',
+            'veinti uno con diez',
+            'cero con veinticuatro',
+            'cero',
+            'menos doscientos treinta con cincuenta'
         ]
 
         for result, number in zip(results, numbers):


### PR DESCRIPTION
Strip result numbers.

**Before**

``` python
number_to_letter(1235)
>>> 'mil doscientos treinta y cinco  '
```

**After**

``` python
number_to_letter(1235)
>>> 'mil doscientos treinta y cinco'
```
